### PR TITLE
DocumentPage with searchable gallery and IIIF viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "leaflet-curve": "^1.0.0",
     "leaflet.markercluster": "^1.5.3",
     "lodash.debounce": "^4.0.8",
+    "mirador": "^3.3.0",
     "module": "github:JohnMulligan/Leaflet.curve",
     "multi-nested-select": "^1.2.1",
     "plotly.js": "^2.23.2",

--- a/src/components/DocumentComponents/MiradorViewer.tsx
+++ b/src/components/DocumentComponents/MiradorViewer.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import mirador from "mirador"
+
+type WorkspaceAction = 'Add' | 'Remove' | 'None'
+
+interface MiradorViewerProps {
+    workspaceAction: WorkspaceAction,
+    manifestUrlBase: string,
+    domId: string,
+    manifestId: string,
+    onWorkspaceAction: (manifestId: string) => void,
+    onClose?: () => boolean
+}
+
+const findWin = (store: any, manifestId: string): any =>
+    Object.values(store.getState().windows)
+        .find((w: any) => w.manifestId === manifestId)
+
+const MiradorViewer = ({ manifestUrlBase, manifestId, domId, workspaceAction, onWorkspaceAction, onClose }: MiradorViewerProps) => {
+    const [ready, setReady] = useState(false)
+    const [target, setTarget] = useState(null)
+    useEffect(() => {
+        setTarget(mirador.viewer({ id: domId }))
+    }, [domId])
+    useEffect(() => {
+        if (!target) {
+            return
+        }
+        const store = mirador.selectors.miradorSlice(target).store
+        const path = `${manifestUrlBase}/${manifestId}`
+        const match = Object.values(store.getState().manifests).find(w => w.id === path)
+        if (!match) {
+            // Add the manifest.
+            const addRes = mirador.actions.addResource(path)
+            store.dispatch(addRes)
+        }
+        // - Close any other window in the viewer.
+        for (const winKey of Object.keys(store.getState().windows)) {
+            const rmw = mirador.actions.removeWindow(winKey)
+            store.dispatch(rmw)
+        }
+        // - Create a window with the manifest...
+        let canvasLoaded = false
+        store.subscribe(() => {
+            if (canvasLoaded && onClose && Object.keys(store.getState().windows).length === 0) {
+                onClose()
+            }
+            if (canvasLoaded || (store.getState().manifests[path]?.isFetching ?? true)) {
+                return
+            }
+            canvasLoaded = true
+            try {
+                const win = findWin(store, path)
+                const displayAction = mirador.actions.setCanvas(
+                    win.id,
+                    `https://voyages-docs.org/${manifestId}/canvas1`
+                )
+                store.dispatch(displayAction)
+                const getButton = (className: string) => {
+                    const matches = document.getElementsByClassName(className)
+                    if (matches.length === 1) {
+                        return matches[0]
+                    }
+                    return null
+                }
+                const removeButton = (className: string) => getButton(className)?.remove()
+                // Remove buttons from the UI.
+                removeButton('mirador-window-maximize')
+                if (!onClose) {
+                    removeButton('mirador-window-close')
+                }
+                removeButton('workspaceBtn')
+                if (workspaceAction !== 'None') {
+                    const workspaceBtn = document.createElement('button')
+                    workspaceBtn.style.minWidth = "260px"
+                    workspaceBtn.className = `workspaceBtn MuiButtonBase-root MuiFab-root mirador9 MuiFab-sizeMedium MuiFab-extended MuiFab-${workspaceAction === 'Add' ? 'primary' : 'danger'} mirador10`
+                    const icon = workspaceAction === 'Add'
+                        ? `<svg class="MuiSvgIcon-root" focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path>
+                            </svg>`
+                        : ''
+                    workspaceBtn.innerHTML = `<span class="MuiFab-label">
+                            ${icon}
+                            ${workspaceAction === 'Add' ? 'Add to my Workspace' : 'Remove from Workspace'}
+                        </span>`
+                    workspaceBtn.onclick = () => onWorkspaceAction(manifestId)
+                    document.getElementsByClassName('mirador-window-top-bar')[0].appendChild(workspaceBtn)
+                }
+            } catch (e) {
+                console.log(e)
+            }
+            setReady(true)
+        })
+        store.dispatch(mirador.actions.fetchManifest(path))
+        store.dispatch(mirador.actions.addWindow({ manifestId: path }))
+        // - Maximize the window.
+        for (const winKey of Object.keys(store.getState().windows)) {
+            const maxw = mirador.actions.maximizeWindow(winKey)
+            store.dispatch(maxw)
+        }
+    }, [target, manifestUrlBase, manifestId])
+    // We use the ready flag to hide the Mirador UI while the manifest window is
+    // loaded. This prevents the user from seeing the Mirador app without any
+    // windows for a brief moment.
+    return <div id={domId} style={{ opacity: ready ? 1 : 0 }}></div>
+}
+
+export default MiradorViewer

--- a/src/pages/DocumentPage.tsx
+++ b/src/pages/DocumentPage.tsx
@@ -1,20 +1,288 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-import LOADINGLOGO from '@/assets/sv-logo_v2_notext.svg';
+import { InputBase, Paper, Stack, Tooltip } from '@mui/material';
+import Badge from '@mui/material/Badge';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+import ImageListItemBar from '@mui/material/ImageListItemBar';
+import IconButton from '@mui/material/IconButton';
+import Pagination from '@mui/material/Pagination';
 import HeaderLogoSearch from '@/components/NavigationComponents/Header/HeaderSearchLogo';
+import MiradorViewer from '@/components/DocumentComponents/MiradorViewer';
+// Icons
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
+import BookmarksIcon from '@mui/icons-material/Bookmarks';
+import SearchIcon from '@mui/icons-material/Search';
+
+
+// Note to @JohnMulligan: I (@dellamonica) see that the project is using
+// lodash.debounce, but it does not seem to integrate nicely with React hooks.
+// The following hook is a 5 line implementation that does debouncing just fine
+// together with useState.
+
+function useDebounce<T>(value: T, wait: number = 500) {
+  const [debounceValue, setDebounceValue] = useState<T>(value);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounceValue(value);
+    }, wait);
+    return () => clearTimeout(timer);
+  }, [value, wait]);
+  return debounceValue;
+}
+
+// Note: while the Documents API is under development, the schemas and fetch
+// code are placed here. They can be later wrapped by createApi.
+
+interface DocumentEntitySearchModel {
+  typename: string,
+  keys: string[]
+}
+
+interface DocumentSearchModel {
+  label: string,
+  entities: DocumentEntitySearchModel[],
+  results_page: number,
+  page_size: number
+}
+
+interface DocumentItemInfo {
+  key: string,
+  label: string,
+  revision_number: number,
+  thumb: string | null
+}
+
+interface DocumentSearchApiResult {
+  matches: number,
+  results: DocumentItemInfo[]
+}
+
+type DocumentSearchApi = (search: DocumentSearchModel) => Promise<DocumentSearchApiResult>
+
+const docSearch: DocumentSearchApi = async (search) => {
+  const res = await fetch('https://daast.azurewebsites.net/api/search', {
+    'method': 'POST',
+    'body': JSON.stringify(search)
+  })
+  return (await res.json()) as DocumentSearchApiResult
+}
+
+interface DocumentPaginationSource {
+  count: number,
+  currentPage?: number,
+  getPage: (pageNum: number, pageSize: number) => Promise<DocumentItemInfo[]>
+}
+
+interface DocumentSearchBoxProps {
+  onClick?: () => void,
+  onUpdate: (source: DocumentPaginationSource) => void
+}
+
+const DocumentSearchBox = ({ onClick, onUpdate }: DocumentSearchBoxProps) => {
+  const [searchText, setSearchText] = useState('')
+  const debouncedSearch = useDebounce(searchText, 500)
+  const search = (pageNum: number, pageSize: number) => {
+    const model: DocumentSearchModel = {
+      label: searchText,
+      results_page: pageNum,
+      page_size: pageSize,
+      entities: []
+    }
+    try {
+      let modSearch = searchText.replace(/([a-z0-9]+)/ig, '"$1"')
+      const structuredSearch = JSON.parse(`{ ${modSearch} }`)
+      const { label, voyages } = structuredSearch
+      if (label || voyages) {
+        model.label = label ?? ''
+        if (voyages) {
+          model.entities.push({
+            typename: 'Voyages',
+            keys: Array.isArray(voyages) ? voyages : [voyages]
+          })
+        }
+      }
+    } catch {
+    }
+    return docSearch(model)
+  }
+  useEffect(() => {
+    const update = async () => {
+      const { matches: count } = await search(1, 1)
+      const paginationSource: DocumentPaginationSource = {
+        count,
+        getPage: async (pageNum, pageSize) => {
+          const { results } = await search(pageNum, pageSize)
+          return results
+        }
+      }
+      onUpdate(paginationSource)
+    }
+    update()
+  }, [debouncedSearch])
+  return <Paper
+    onClick={onClick}
+    component="form"
+    sx={{ p: '2px 4px', display: 'flex', alignItems: 'center', width: 400 }}>
+    <InputBase
+      onFocus={onClick}
+      sx={{ ml: 1, flex: 1 }}
+      placeholder="Search Documents"
+      inputProps={{ 'aria-label': 'search documents' }}
+      onChange={e => setSearchText(e.target.value)}
+    />
+    <SearchIcon />
+  </Paper>
+}
+
+interface DocumentGalleryProps {
+  title: string,
+  pageSize: number,
+  source: DocumentPaginationSource,
+  thumbSize: number,
+  onDocumentOpen: (doc: DocumentItemInfo) => void
+  onPageChange: (page: number) => void,
+}
+
+const DocumentGallery = ({ title, pageSize, source, thumbSize, onDocumentOpen, onPageChange }: DocumentGalleryProps) => {
+  const [contents, setContents] = useState<DocumentItemInfo[]>([])
+  const numPages = Math.ceil(source.count / pageSize)
+  useEffect(() => {
+    const refresh = async () => {
+      setContents(await source.getPage(Math.min(numPages, source.currentPage ?? 1), pageSize))
+    }
+    refresh()
+  }, [source])
+  return <>
+    <h2>{title} <small>(Item count: {source.count})</small></h2>
+    <Pagination count={numPages} page={source.currentPage ?? 1} onChange={(_, p) => onPageChange(p)} />
+    <ImageList sx={{ width: '80vw' }} cols={5} rowHeight={thumbSize}>
+      {contents.map((item) => (
+        <ImageListItem key={item.key} style={{ width: thumbSize, height: thumbSize }}>
+          {item.thumb && <img
+            width={thumbSize}
+            height={thumbSize}
+            src={item.thumb}
+            alt={item.label}
+            loading="lazy"
+          />}
+          <ImageListItemBar
+            title={item.label}
+            actionIcon={
+              <IconButton
+                sx={{ color: 'rgba(255, 255, 255, 0.54)' }}
+                color="primary"
+                aria-label={`Open ${item.label}`}
+                onClick={() => onDocumentOpen(item)}
+              >
+                <AutoStoriesIcon />
+              </IconButton>
+            }
+          />
+        </ImageListItem>
+      ))}
+    </ImageList>
+  </>
+}
+
+const UserWorkspaceLocalStorageKey = 'my-workspace'
+
+const getWorkspace = () => {
+  const stored = localStorage.getItem(UserWorkspaceLocalStorageKey)
+  const items: DocumentItemInfo[] = JSON.parse(stored ?? '[]')
+  return items
+}
+
+const getWorkspaceSource = () => {
+  const items = getWorkspace()
+  const paginationSource: DocumentPaginationSource = {
+    count: items.length,
+    getPage: (pageNum, pageSize) =>
+      Promise.resolve(
+        items.slice(
+          (pageNum - 1) * pageSize,
+          Math.min(items.length, pageNum * pageSize)))
+  }
+  return paginationSource
+}
+
+type DocumentPageTab = 'Search' | 'Workspace'
+
+type DocumentSources = Partial<Record<DocumentPageTab, DocumentPaginationSource>>
+
+const docIndexInWorkspace = (doc: DocumentItemInfo, items?: DocumentItemInfo[]) => {
+  items ??= getWorkspace()
+  return items.findIndex(info => info.key === doc.key)
+}
+
 const DocumentPage: React.FC = () => {
+  // Our state is composed of sources for each DocumentPageTab, which allow
+  // switching tabs without loss of state.
+  const [sources, setSources] = useState<DocumentSources>({
+    Workspace: getWorkspaceSource()
+  })
+  const [doc, setDoc] = useState<DocumentItemInfo | null>(null)
+  const [tab, setTab] = useState<DocumentPageTab>('Search')
+  const refreshWorkspace = () => {
+    setSources({ ...sources, Workspace: getWorkspaceSource() })
+  }
+  const handleMiradorClose = () => {
+    setDoc(null)
+    return true
+  }
+  const handleWorkspaceAction = (manifestId: string) => {
+    if (!doc || doc.key !== manifestId) {
+      console.log('Unexpected item added to collection')
+      return
+    }
+    const items = getWorkspace()
+    const matchIndex = docIndexInWorkspace(doc, items)
+    if (matchIndex >= 0) {
+      // Already in the workspace, so we remove it.
+      if (!confirm('Remove document from workspace?')) {
+        return
+      }
+      items.splice(matchIndex, 1)
+    } else {
+      items.push(doc)
+    }
+    localStorage.setItem(UserWorkspaceLocalStorageKey, JSON.stringify(items))
+    refreshWorkspace()
+  }
+  const tabSource = sources[tab]
   return (
-    <>
-      <HeaderLogoSearch />
-      <div style={{ marginTop: '15%', textAlign: 'center' }}>
-        <div>Document page is coming soon</div>
-        <img
-          src={LOADINGLOGO}
-          alt="document"
-          style={{ width: '30%', padding: '5%' }}
-        />
+    <Stack direction="row">
+      {!doc && <HeaderLogoSearch />}
+      <div style={{ marginTop: '5%', marginLeft: '5%', width: '90vw', height: '90vh', display: doc ? 'none' : 'block' }}>
+        <div style={{ display: 'flex' }}>
+          <div style={ tab === 'Workspace' ? { opacity: 0.33 } : {} }>
+            <DocumentSearchBox onClick={() => setTab('Search')} onUpdate={src => setSources({ ...sources, Search: src })} />
+          </div>
+          {sources.Workspace &&
+            <Tooltip title={sources.Workspace.count ? "My Workspace Documents" : "No Documents added to My Workspace yet"}>
+              <IconButton aria-label="my-workspace" onClick={() => setTab('Workspace')}>
+                <Badge badgeContent={sources.Workspace.count + ''} color="primary">
+                  <BookmarksIcon color="action" />
+                </Badge>
+              </IconButton>
+            </Tooltip>}
+        </div>
+        {tabSource && <DocumentGallery
+          title={tab}
+          source={tabSource}
+          pageSize={15}
+          thumbSize={200}
+          onDocumentOpen={setDoc}
+          onPageChange={pageNum => setSources({ ...sources, [tab]: { ...tabSource, currentPage: pageNum } })} />}
       </div>
-    </>
+      {doc && <MiradorViewer
+        manifestUrlBase='https://daast.azurewebsites.net/api/manifest'
+        domId='__mirador'
+        onClose={handleMiradorClose}
+        manifestId={doc.key}
+        workspaceAction={docIndexInWorkspace(doc) >= 0 ? 'Remove' : 'Add'}
+        onWorkspaceAction={handleWorkspaceAction} />}
+    </Stack>
   );
 };
 


### PR DESCRIPTION
Adding a DocumentPage with searchable gallery.
Created wrapper MiradorViewer for the visualization of IIIF manifests.

@JohnMulligan, for now I placed the code in DocumentPage, but if the UI is approved by the users, we should follow the current organization for the code and spin off components to different files in the src/components folder.

I'm *not* using redux, dispatches, sagas and what not. Feel free to review the code and suggest changes to follow the approach taken.