### PR TITLE
For deploy on 30May

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,7 @@ const App: React.FC = () => {
       <QueryClientProvider client={queryClient}>
         <DocumentViewerProvider>
           <Routes>
-            {nodeClass && ID && <Route path={`${nodeClass}/${ID}/${variable}`} element={<TabsSelect />} />}
+            {nodeClass && ID && <Route path={`${nodeClass}/${ID}`} element={<TabsSelect />} />}
             <Route path="/" element={<HomePage />} />
             {saveSearchURL && nodeClass && <Route
               path={`${saveSearchURL}`}

--- a/src/components/FilterComponents/Autocomplete/AutoCompleteListBox.tsx
+++ b/src/components/FilterComponents/Autocomplete/AutoCompleteListBox.tsx
@@ -94,6 +94,7 @@ export default function AutoCompleteListBox() {
         const values = autoValueList.map<AutoCompleteOption>((item: string) => ({
             value: item,
         }));
+
         setSelectedValue(() => values);
         dispatch(setFilterObject(filter));
     }, [varName, styleName]);

--- a/src/components/FilterComponents/Autocomplete/FilterTextNameEnslaversBox.tsx
+++ b/src/components/FilterComponents/Autocomplete/FilterTextNameEnslaversBox.tsx
@@ -16,7 +16,7 @@ const FilterTextNameEnslaversBox: FunctionComponent<FilterTextNameEnslaversProps
         const newValue = event.target.value;
         dispatch(setEnslaversName(newValue))
         if (newValue.length === 0) {
-            setTextError('Please make a selection');
+            setTextError(`Please type enslavers name, can't be empty`);
             dispatch(setEnslaversName(''));
         } else {
             setTextError('');
@@ -25,12 +25,18 @@ const FilterTextNameEnslaversBox: FunctionComponent<FilterTextNameEnslaversProps
 
     const handleKeyDownTextFilter = (value: string) => {
         if (value.length === 0) {
-            setTextError('Please make a selection');
+            setTextError(`Please type enslavers name, can't be empty`);
         } else {
             dispatch(setEnslaversName(value));
             setTextError('');
         }
     }
+    const handleFocus = () => {
+        if (enslaverName.length === 0) {
+            setTextError(`Please type enslavers name, can't be empty`);
+        }
+    };
+
 
     return (
         <TextField
@@ -38,6 +44,7 @@ const FilterTextNameEnslaversBox: FunctionComponent<FilterTextNameEnslaversProps
             fullWidth
             value={enslaverName}
             onChange={handleTextInputChange}
+            onFocus={handleFocus}
             onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                     handleKeyDownTextFilter(enslaverName);

--- a/src/components/FilterComponents/Autocomplete/FilterTextNameEnslaversBox.tsx
+++ b/src/components/FilterComponents/Autocomplete/FilterTextNameEnslaversBox.tsx
@@ -16,7 +16,7 @@ const FilterTextNameEnslaversBox: FunctionComponent<FilterTextNameEnslaversProps
         const newValue = event.target.value;
         dispatch(setEnslaversName(newValue))
         if (newValue.length === 0) {
-            setTextError('Required could be more concise');
+            setTextError('Please make a selection');
             dispatch(setEnslaversName(''));
         } else {
             setTextError('');
@@ -25,7 +25,7 @@ const FilterTextNameEnslaversBox: FunctionComponent<FilterTextNameEnslaversProps
 
     const handleKeyDownTextFilter = (value: string) => {
         if (value.length === 0) {
-            setTextError('Required could be more concise');
+            setTextError('Please make a selection');
         } else {
             dispatch(setEnslaversName(value));
             setTextError('');

--- a/src/components/FilterComponents/GeoTreeSelect/GeoTreeSelected.tsx
+++ b/src/components/FilterComponents/GeoTreeSelect/GeoTreeSelected.tsx
@@ -199,6 +199,7 @@ const GeoTreeSelected: React.FC<GeoTreeSelectedProps> = ({ type }) => {
     const filterObjectUpdate = {
       filter: filteredFilters,
     };
+
     const filterObjectString = JSON.stringify(filterObjectUpdate);
     localStorage.setItem('filterObject', filterObjectString);
     if ((styleNameRoute === TYPESOFDATASET.allVoyages || styleNameRoute === TYPESOFDATASETPEOPLE.allEnslaved || styleNameRoute === allEnslavers) && filteredFilters.length > 0) {

--- a/src/components/PresentationComponents/Cards/Cards.tsx
+++ b/src/components/PresentationComponents/Cards/Cards.tsx
@@ -209,7 +209,7 @@ const VoyageCard = () => {
                             const extraElements: JSX.Element[] = []
                             if (isDocumentReference(value)) {
                               valueToRender += ' '
-                              extraElements.push(<i className="fa fa-file-text" aria-hidden="true"></i>);
+                              extraElements.push(<i key={index} className="fa fa-file-text" aria-hidden="true"></i>);
                               additionalStyles.borderColor = 'blue';
                               additionalStyles.borderWidth = 1;
                               additionalStyles.borderStyle = 'solid';

--- a/src/components/PresentationComponents/Cards/Cards.tsx
+++ b/src/components/PresentationComponents/Cards/Cards.tsx
@@ -230,6 +230,7 @@ const VoyageCard = () => {
                                 style={{ padding: '2px 0' }}
                               >
                                 <span
+                                  key={`${index}-${value}`}
                                   {...additionalProps}
                                   style={{ ...styleCard, ...additionalStyles }}
                                 >{`${valueToRender}`}

--- a/src/components/PresentationComponents/LadingPage/EnslaversBlogs.tsx
+++ b/src/components/PresentationComponents/LadingPage/EnslaversBlogs.tsx
@@ -3,7 +3,12 @@ import '@/style/landing.scss';
 import ENSLAVERS from '@/assets/enslavers-blog.png';
 import ButtonLearnMore from '@/components/SelectorComponents/ButtonComponents/ButtonLearnMore';
 import { ENSALVERSPAGE, TRANSATLANTICENSLAVERS } from '@/share/CONST_DATA';
+import { translationHomepage } from '@/utils/functions/translationLanguages';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/store';
 const EnslaversBlogs: React.FC = () => {
+    const { languageValue } = useSelector((state: RootState) => state.getLanguages);
+    const translatedHomepage = translationHomepage(languageValue)
     return (
         <div className="container-enslavers">
             <div className="enslavers-content">
@@ -11,15 +16,8 @@ const EnslaversBlogs: React.FC = () => {
                     <img src={ENSLAVERS} alt="Enslavers" className="register-img" />
                 </div>
                 <div className="enslavers-content-detail">
-                    <h1>Enslavers</h1>
-                    <p>
-                        At the foundation of the African diaspora lay an enslaver (or an owner),
-                        the enslaved person, and the movement of the latter induced by the former
-                        (this could be one of the various slave trades, a runaway slave or a single transaction between buyer and seller).
-                        Any movement of property or changes in that property’s status generated documentation – in the case of both slaves
-                        and their owners, these were typically accounts, baptismal certificates, newspapers,
-                        or shipping records.
-                    </p>
+                    <h1>{translatedHomepage.homeEnslavers}</h1>
+                    <p>{translatedHomepage.homeEnslaversDes}</p>
                     <ButtonLearnMore path={`${ENSALVERSPAGE}${TRANSATLANTICENSLAVERS}#people`} />
                 </div>
             </div>

--- a/src/components/PresentationComponents/Map/LeafletMap.tsx
+++ b/src/components/PresentationComponents/Map/LeafletMap.tsx
@@ -44,8 +44,6 @@ import {
   checkPagesRouteForEnslaved,
   checkPagesRouteForVoyages,
   checkPagesRouteMapEstimates,
-  checkPagesRouteMapURLForEnslaved,
-  checkPagesRouteMapURLForVoyages,
 } from '@/utils/functions/checkPagesRoute';
 import { setFilterObject } from '@/redux/getFilterSlice';
 import { fetchEstimatesMap } from '@/fetch/estimateFetch/fetchEstimatesMap';
@@ -176,11 +174,7 @@ export const LeafletMap = ({ setZoomLevel, zoomLevel }: LeafletMapProps) => {
     let response;
     if (checkPagesRouteForVoyages(styleNamePage! || nodeTypeURL!)) {
       response = await dispatch(fetchVoyagesMap(dataSend)).unwrap();
-    } else if (checkPagesRouteMapURLForVoyages(nodeTypeURL!)) {
-      response = await dispatch(fetchVoyagesMap(dataSend)).unwrap();
     } else if (checkPagesRouteForEnslaved(styleNamePage!)) {
-      response = await dispatch(fetchEnslavedMap(dataSend)).unwrap();
-    } else if (checkPagesRouteMapURLForEnslaved(nodeTypeURL!)) {
       response = await dispatch(fetchEnslavedMap(dataSend)).unwrap();
     } else if (checkPagesRouteMapEstimates(styleNamePage!)) {
       response = await dispatch(fetchEstimatesMap(dataSend)).unwrap();

--- a/src/components/PresentationComponents/Map/LeafletMapURL.tsx
+++ b/src/components/PresentationComponents/Map/LeafletMapURL.tsx
@@ -43,8 +43,6 @@ import { usePageRouter } from '@/hooks/usePageRouter';
 import {
     checkPagesRouteForEnslaved,
     checkPagesRouteForVoyages,
-    checkPagesRouteMapURLForEnslaved,
-    checkPagesRouteMapURLForVoyages,
 } from '@/utils/functions/checkPagesRoute';
 
 interface LeafletMapProps {
@@ -62,9 +60,10 @@ export const LeafletMapURL = ({ setZoomLevel, zoomLevel }: LeafletMapProps) => {
         (state: RootState) => state.getNodeEdgesAggroutesMapData
     );
     const {
-        nodeTypeURL: voyageURLID, typeOfPathURL: styleNamePage,
+        voyageURLID, endpointPath: styleNamePage,
     } = usePageRouter();
     const [regionPlace, setRegionPlace] = useState<string>('region');
+    console.log({ voyageURLID, styleNamePage })
 
     const [loading, setLoading] = useState<boolean>(false);
     const hasFetchedPlaceRef = useRef(false);
@@ -147,13 +146,12 @@ export const LeafletMapURL = ({ setZoomLevel, zoomLevel }: LeafletMapProps) => {
 
         if (checkPagesRouteForVoyages(styleNamePage!)) {
             response = await dispatch(fetchVoyagesMap(dataSend)).unwrap();
-        } else if (checkPagesRouteMapURLForVoyages(styleNamePage!)) {
-            response = await dispatch(fetchVoyagesMap(dataSend)).unwrap();
         } else if (checkPagesRouteForEnslaved(styleNamePage!)) {
             response = await dispatch(fetchEnslavedMap(dataSend)).unwrap();
-        } else if (checkPagesRouteMapURLForEnslaved(styleNamePage!)) {
-            response = await dispatch(fetchEnslavedMap(dataSend)).unwrap();
         }
+        // else if (checkPagesRouteMapURLForEnslaved(styleNamePage!)) {
+        //     response = await dispatch(fetchEnslavedMap(dataSend)).unwrap();
+        // }
 
         if (response) {
 

--- a/src/components/PresentationComponents/Map/MAPS.tsx
+++ b/src/components/PresentationComponents/Map/MAPS.tsx
@@ -12,11 +12,11 @@ function MAPComponents() {
   const dispatch: AppDispatch = useDispatch();
   const [zoomLevel, setZoomLevel] = useState<number>(3);
   const mapRef = useRef(null);
-  const { styleName: styleNameRoute, nodeTypeURL: ID, voyageURLID, typeOfPathURL } = usePageRouter()
-
+  const { styleName: styleNameRoute, voyageURLID: ID, typeOfPathURL, nodeTypeURL } = usePageRouter()
 
   const { nameIdURL } = useSelector((state: RootState) => state.getFilter);
   let isUrLMap = false;
+
   useEffect(() => {
     const NUMBER = '0123456789'
 
@@ -25,14 +25,16 @@ function MAPComponents() {
         isUrLMap = true
       }
     }
-    if ((typeOfPathURL === VOYAGESTYPE || (typeOfPathURL === VOYAGESNODECLASS)) && (isUrLMap)) {
+    console.log({ nameIdURL })
+    if ((nodeTypeURL === VOYAGESTYPE || (nodeTypeURL === VOYAGESNODECLASS)) && (isUrLMap)) {
       dispatch(setVariableNameIdURL('voyage_id'));
-    } else if ((typeOfPathURL === ENSLAVEDNODE) && (isUrLMap)) {
+    } else if ((nodeTypeURL === ENSLAVEDNODE) && (isUrLMap)) {
       dispatch(setVariableNameIdURL('enslaved_id'));
-    } else if ((typeOfPathURL === ENSLAVERSNODE) && (isUrLMap)) {
+    } else if ((nodeTypeURL === ENSLAVERSNODE) && (isUrLMap)) {
       dispatch(setVariableNameIdURL('voyage_enslavement_relations__relation_enslavers__enslaver_alias__identity__id'));
     }
-  }, [])
+  }, [nameIdURL])
+
 
   const calassNameMap = (nameIdURL || styleNameRoute === ESTIMATES) ? 'mobile-responsive-map-url' : 'mobile-responsive-map'
   return (

--- a/src/components/PresentationComponents/PivotTables/PivotTables.tsx
+++ b/src/components/PresentationComponents/PivotTables/PivotTables.tsx
@@ -118,7 +118,7 @@ const PivotTables = () => {
       width: getMobileMaxWidth(maxWidth),
       height: getMobileMaxHeightPivotTable(height),
     });
-  }, [width, maxWidth,]);
+  }, [width, maxWidth]);
 
   const defaultColDef = useMemo(() => {
     return {
@@ -173,6 +173,7 @@ const PivotTables = () => {
     const { label, title, ...filteredFilter } = filter;
     return filteredFilter;
   });
+  console.log({ newFilters })
   const dataSend: PivotTablesPropsRequest = {
     columns: column_vars,
     rows: updatedRowsValue,
@@ -184,6 +185,7 @@ const PivotTables = () => {
     limit: rowsPerPage,
     filter: newFilters || [],
   }
+
 
   if (inputSearchValue) {
     dataSend['global_search'] = inputSearchValue
@@ -247,6 +249,7 @@ const PivotTables = () => {
       window.removeEventListener('resize', handleResize);
     };
   }, [
+    filtersObj,
     pivotValueOptions.cell_vars,
     pivotValueOptions.column_vars,
     pivotValueOptions.row_vars,

--- a/src/components/PresentationComponents/Tables/Tables.tsx
+++ b/src/components/PresentationComponents/Tables/Tables.tsx
@@ -105,12 +105,17 @@ const Tables: React.FC = () => {
         if (!isLoading && !isError && tableCellStructure) {
             setTableCell(tableCellStructure as TableCellStructure[]);
         }
-
-        if (tablesCell.length > 0) {
+        const storedValueVisibleColumns = localStorage.getItem('visibleColumns');
+        if (storedValueVisibleColumns) {
+            const parsedValue = JSON.parse(storedValueVisibleColumns);
+            dispatch(setVisibleColumn(parsedValue));
+        } else if (tablesCell.length > 0 && !storedValueVisibleColumns) {
             const visibleColumns = tablesCell
                 .filter((cell: any) => cell.visible)
                 .map((cell: any) => cell.colID);
             dispatch(setVisibleColumn(visibleColumns));
+            const visibleColumnsString = JSON.stringify(visibleColumns);
+            localStorage.setItem('visibleColumns', visibleColumnsString);
         }
 
         const headerColor = getHeaderColomnColor(styleNameRoute!);
@@ -238,8 +243,9 @@ const Tables: React.FC = () => {
             const visibleColumns = allColumns
                 .filter((column: any) => column.isVisible())
                 .map((column: any) => column.getColId());
-
             dispatch(setVisibleColumn(visibleColumns));
+            const visibleColumnsString = JSON.stringify(visibleColumns);
+            localStorage.setItem('visibleColumns', visibleColumnsString);
         },
         [dispatch]
     );

--- a/src/components/SelectorComponents/ButtonComponents/ResetAllButton.tsx
+++ b/src/components/SelectorComponents/ButtonComponents/ResetAllButton.tsx
@@ -2,7 +2,7 @@ import { usePageRouter } from '@/hooks/usePageRouter';
 import { setIsViewButtonViewAllResetAll } from '@/redux/getShowFilterObjectSlice';
 import { AppDispatch, RootState } from '@/redux/store';
 import { allEnslavers } from '@/share/CONST_DATA';
-import { RangeSliderState, TYPESOFDATASET, TYPESOFDATASETPEOPLE } from '@/share/InterfaceTypes';
+import { TYPESOFDATASET, TYPESOFDATASETPEOPLE } from '@/share/InterfaceTypes';
 import '@/style/homepage.scss'
 import { translationHomepage } from '@/utils/functions/translationLanguages';
 import { useEffect, useRef } from 'react';

--- a/src/components/SelectorComponents/Cascading/CascadingMenu.tsx
+++ b/src/components/SelectorComponents/Cascading/CascadingMenu.tsx
@@ -39,7 +39,6 @@ export default function CascadingMenu(props: CascadingMenuProps) {
   }, [styleNamePeople, currentBlockName]);
 
   const handleResetAll = () => {
-    console.log('Reset')
     dispatch(resetAllStateToInitailState())
     const keysToRemove = Object.keys(localStorage);
     keysToRemove.forEach((key) => {
@@ -48,6 +47,7 @@ export default function CascadingMenu(props: CascadingMenuProps) {
       }
     });
     localStorage.removeItem('saveSearchID');
+    localStorage.removeItem('visibleColumns');
     window.location.reload()
   };
 

--- a/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
+++ b/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
@@ -126,7 +126,6 @@ export const MenuListsDropdown = () => {
     };
     loadFilterCellStructure();
   }, [styleNameRoute, languageValue, isOpenDialog]);
-
   useEffect(() => {
     const storedValue = localStorage.getItem('filterObject');
     if (!storedValue) return;
@@ -237,7 +236,6 @@ export const MenuListsDropdown = () => {
   };
 
   const handleApplyEnslaversDialog = (roles: RolesProps[], name: string, ops: string) => {
-    console.log("roles")
     if (roles.length === 0) {
       setTextRoleListError('Required could be more concise')
     }

--- a/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
+++ b/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/styleMUI';
 import { useState, MouseEvent, useEffect } from 'react';
 import { PaperDraggable } from './PaperDraggable';
-import { setEnslaversNameAndRole, setIsChange, setKeyValueName, setOpsRole } from '@/redux/getRangeSliderSlice';
+import { setEnslaversNameAndRole, setIsChange, setKeyValueName, setListEnslavers, setOpsRole } from '@/redux/getRangeSliderSlice';
 import { setIsChangeAuto, setTextFilterValue } from '@/redux/getAutoCompleteSlice';
 import { setIsOpenDialog } from '@/redux/getScrollPageSlice';
 import { ArrowDropDown, ArrowRight } from '@mui/icons-material';
@@ -100,6 +100,7 @@ export const MenuListsDropdown = () => {
   const [filterMenu, setFilterMenu] = useState<FilterMenuList[]>([]);
   const [textError, setTextError] = useState<string>('')
   const [textRoleListError, setTextRoleListError] = useState<string>('')
+  const isButtonDisabled = enslaverName === '' && typeData === TYPES.EnslaverNameAndRole;
 
   useEffect(() => {
     const loadFilterCellStructure = async () => {
@@ -193,6 +194,7 @@ export const MenuListsDropdown = () => {
       dispatch(setIsOpenDialog(true));
       if (roles) {
         dispatch(setEnslaversNameAndRole(roles))
+        dispatch(setListEnslavers(roles));
       }
     }
   };
@@ -238,8 +240,8 @@ export const MenuListsDropdown = () => {
     if (roles.length === 0) {
       setTextRoleListError('Please make a selection')
     }
-    if (!name) {
-      setTextError('Please make a selection')
+    if (name === '') {
+      setTextError(`Please type enslavers name, can't be empty`)
     }
     const newRoles: string[] = roles.map((ele) => ele.value);
     updatedEnslaversRoleAndNameToLocalStorage(dispatch, styleNameRoute!, newRoles as string[], name, varName, ops!)
@@ -445,7 +447,7 @@ export const MenuListsDropdown = () => {
           {varName && opsRoles !== 'btw' && ((typeData === TYPES.CharField && ops === 'icontains') || (typeData === TYPES.VoyageID && opsRoles === 'exact') || (typeData === TYPES.EnslaverNameAndRole) || (typeData === TYPES.MultiselectList))
             && <Button
               autoFocus
-              disabled={listEnslavers.length === 0 && enslaverName === '' && typeData === TYPES.EnslaverNameAndRole}
+              disabled={isButtonDisabled}
               type='submit'
               onClickCapture={() => {
                 if (typeData === TYPES.EnslaverNameAndRole) {
@@ -457,8 +459,8 @@ export const MenuListsDropdown = () => {
               sx={{
                 color: 'white', textTransform: 'unset',
                 height: 30,
-                cursor: listEnslavers.length === 0 && enslaverName === '' && typeData === TYPES.EnslaverNameAndRole ? 'not-allowed' : 'pointer',
-                backgroundColor: listEnslavers.length === 0 && enslaverName === '' && typeData === TYPES.EnslaverNameAndRole ? getColorHoverBackgroundCollection(styleNameRoute!) : getColorBackground(styleNameRoute!),
+                cursor: isButtonDisabled ? 'not-allowed' : 'pointer',
+                backgroundColor: isButtonDisabled ? getColorHoverBackgroundCollection(styleNameRoute!) : getColorBackground(styleNameRoute!),
                 fontSize: '0.80rem',
                 '&:hover': {
                   backgroundColor: getColorHoverBackgroundCollection(styleNameRoute!),

--- a/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
+++ b/src/components/SelectorComponents/Cascading/MenuListsDropdown.tsx
@@ -98,9 +98,8 @@ export const MenuListsDropdown = () => {
   const [isClickMenu, setIsClickMenu] = useState<boolean>(false);
   const [ops, setOps] = useState<string>('');
   const [filterMenu, setFilterMenu] = useState<FilterMenuList[]>([]);
-  const [textError, setTextError] = useState<string>('') //!enslaverName ? 'Required could be more concise' : ''
-  const [textRoleListError, setTextRoleListError] = useState<string>('') //listEnslavers.length === 0 ? 'Required could be more concise' : ''
-
+  const [textError, setTextError] = useState<string>('')
+  const [textRoleListError, setTextRoleListError] = useState<string>('')
 
   useEffect(() => {
     const loadFilterCellStructure = async () => {
@@ -237,10 +236,10 @@ export const MenuListsDropdown = () => {
 
   const handleApplyEnslaversDialog = (roles: RolesProps[], name: string, ops: string) => {
     if (roles.length === 0) {
-      setTextRoleListError('Required could be more concise')
+      setTextRoleListError('Please make a selection')
     }
     if (!name) {
-      setTextError('Required could be more concise')
+      setTextError('Please make a selection')
     }
     const newRoles: string[] = roles.map((ele) => ele.value);
     updatedEnslaversRoleAndNameToLocalStorage(dispatch, styleNameRoute!, newRoles as string[], name, varName, ops!)

--- a/src/components/SelectorComponents/RadioSelected/RadioSelected.tsx
+++ b/src/components/SelectorComponents/RadioSelected/RadioSelected.tsx
@@ -83,7 +83,6 @@ export const RadioSelected: FunctionComponent<
               />
             ))}
           </RadioGroup>
-
           :
           <span className='enlavers-role-radio'>
             <FormLabel id="demo-controlled-radio-buttons-group" style={{ color: '#000', paddingRight: 15 }}>
@@ -104,7 +103,7 @@ export const RadioSelected: FunctionComponent<
               <FormControlLabel
                 value="andlist"
                 control={<Radio />}
-                label={<Typography variant="body1">all of these roles: </Typography>}
+                label={<Typography variant="body1">all of these roles</Typography>}
               />
             </RadioGroup></span>
       }

--- a/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownEnslaversNameRole.tsx
+++ b/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownEnslaversNameRole.tsx
@@ -22,13 +22,13 @@ export const SelectSearchDropdownEnslaversNameRole: FunctionComponent<SelectSear
     (state: RootState) => state.getDataSetCollection
   );
 
-  const { enslaversNameAndRole, listEnslavers } = useSelector((state: RootState) => state.rangeSlider as FilterObjectsState);
+  const { enslaversNameAndRole, listEnslavers, enslaverName } = useSelector((state: RootState) => state.rangeSlider as FilterObjectsState);
 
   const handleSelectedRoleAndName = (event: SyntheticEvent<Element, Event>,
     newValue: RolesProps[]) => {
     if (!newValue) return;
     if (newValue.length === 0) {
-      setTextRoleListError('Required could be more concise')
+      setTextRoleListError('Please make a selection')
     } else {
       setTextRoleListError('')
     }
@@ -38,6 +38,7 @@ export const SelectSearchDropdownEnslaversNameRole: FunctionComponent<SelectSear
   return (
     <Autocomplete
       disableCloseOnSelect
+      // disabled={enslaverName === ''}
       options={enslaversNameAndRole as RolesProps[]}
       multiple
       value={listEnslavers}
@@ -45,6 +46,7 @@ export const SelectSearchDropdownEnslaversNameRole: FunctionComponent<SelectSear
       renderInput={(params) => (
         <div style={{ color: 'red', fontSize: '0.875rem', textAlign: 'left' }}>
           <TextField
+
             {...params}
             variant="outlined"
             label={
@@ -53,7 +55,7 @@ export const SelectSearchDropdownEnslaversNameRole: FunctionComponent<SelectSear
               </Typography>
             }
             placeholder="SelectedOptions"
-            style={{ marginTop: 20 }}
+          // style={{ backgroundColor: enslaverName === '' ? '#e2e2e2' : 'white', marginTop: 20 }}
           />
           <span style={{ color: 'red', fontSize: '0.875rem', marginLeft: 14 }}>{textRoleListError}</span>
         </div>

--- a/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownEnslaversNameRole.tsx
+++ b/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownEnslaversNameRole.tsx
@@ -27,7 +27,7 @@ export const SelectSearchDropdownEnslaversNameRole: FunctionComponent<SelectSear
   const handleSelectedRoleAndName = (event: SyntheticEvent<Element, Event>,
     newValue: RolesProps[]) => {
     if (!newValue) return;
-    if (newValue.length <= 0) {
+    if (newValue.length === 0) {
       setTextRoleListError('Required could be more concise')
     } else {
       setTextRoleListError('')

--- a/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
+++ b/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
@@ -52,11 +52,8 @@ export const SelectSearchDropdownList: FunctionComponent<SelectSearchDropdownLis
       filter.find((filterItem) => filterItem.varName === varName);
     if (!filterByVarName) return;
     const nationList: string[] = filterByVarName.searchTerm as string[];
-    const values = nationList.map<NationalityListProps>((item: string) => ({
-      // Assuming 'item' is the 'name' and you need to set 'id' and 'value' appropriately
-      id: 0, // You might need a function to generate unique IDs
-      name: item,
-      value: 1,
+    const values = nationList.map<NationalityListProps>((name: string) => ({
+      name: name,
     }));
     setNationList(values)
     dispatch(setFilterObject(filter));

--- a/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
+++ b/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
@@ -86,10 +86,10 @@ export const SelectSearchDropdownList: FunctionComponent<SelectSearchDropdownLis
             variant="outlined"
             label={
               <Typography variant="body1" style={{ fontSize: 14 }} height={50}>
-                Selections
+                Selected nationality
               </Typography>
             }
-            placeholder="SelectedOptions"
+            placeholder="Selected nationality"
             style={{ marginTop: 20 }}
           />
         </div>

--- a/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
+++ b/src/components/SelectorComponents/SelectDrowdown/SelectSearchDropdownList.tsx
@@ -1,0 +1,115 @@
+import {
+  Chip,
+  Typography,
+  TextField,
+  Autocomplete,
+} from '@mui/material';
+import { FunctionComponent, SyntheticEvent, useEffect, useState } from 'react';
+import { Filter, FilterObjectsState, NationalityListProps } from '@/share/InterfaceTypes';
+import { getBoderColor } from '@/utils/functions/getColorStyle';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '@/redux/store';
+import { fetchNationalityList } from '@/fetch/voyagesFetch/fetchNationalityList';
+import { setNationalityList } from '@/redux/getNationalityListSlice';
+import { updateNationalityObject } from '@/utils/functions/updateNationalityObject';
+import { usePageRouter } from '@/hooks/usePageRouter';
+import { setFilterObject } from '@/redux/getFilterSlice';
+
+interface SelectSearchDropdownListProps { }
+
+export const SelectSearchDropdownList: FunctionComponent<SelectSearchDropdownListProps> = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const { styleName } = useSelector(
+    (state: RootState) => state.getDataSetCollection
+  );
+  const { varName } = useSelector(
+    (state: RootState) => state.rangeSlider as FilterObjectsState
+  );
+  const { styleName: styleNameRoute } = usePageRouter();
+  const nationalityList = useSelector((state: RootState) => state.getNationalityList.nationalityList);
+  const [nationList, setNationList] = useState<NationalityListProps[]>([]);
+
+  const fetchNationalityData = async () => {
+    try {
+      const response = await fetchNationalityList()
+      if (response) {
+        const { data } = response
+        dispatch(setNationalityList(data))
+      }
+    } catch (error) {
+      console.log('Error fetchNationalityData', error);
+    }
+  }
+  useEffect(() => {
+    fetchNationalityData()
+    const storedValue = localStorage.getItem('filterObject');
+
+    if (!storedValue) return;
+    const parsedValue = JSON.parse(storedValue);
+    const filter: Filter[] = parsedValue.filter;
+    const filterByVarName =
+      filter?.length > 0 &&
+      filter.find((filterItem) => filterItem.varName === varName);
+    if (!filterByVarName) return;
+    const nationList: string[] = filterByVarName.searchTerm as string[];
+    const values = nationList.map<NationalityListProps>((item: string) => ({
+      // Assuming 'item' is the 'name' and you need to set 'id' and 'value' appropriately
+      id: 0, // You might need a function to generate unique IDs
+      name: item,
+      value: 1,
+    }));
+    setNationList(values)
+    dispatch(setFilterObject(filter));
+  }, [varName, styleName]);
+
+
+  const handleSelected = (
+    event: SyntheticEvent<Element, Event>,
+    newValue: NationalityListProps[]
+  ) => {
+    if (!newValue) return;
+    setNationList(newValue);
+    const valueSelect: string[] = newValue.map((ele) => ele.name);
+    updateNationalityObject(dispatch, valueSelect, varName, styleNameRoute!)
+  };
+
+
+  return (
+    <Autocomplete
+      disableCloseOnSelect
+      options={nationalityList as NationalityListProps[]}
+      multiple
+      value={nationList as NationalityListProps[]}
+      onChange={handleSelected}
+      getOptionLabel={(option) => option.name}
+      renderInput={(params) => (
+        <div style={{ color: 'red', fontSize: '0.875rem', textAlign: 'left' }}>
+          <TextField
+            {...params}
+            variant="outlined"
+            label={
+              <Typography variant="body1" style={{ fontSize: 14 }} height={50}>
+                Selections
+              </Typography>
+            }
+            placeholder="SelectedOptions"
+            style={{ marginTop: 20 }}
+          />
+        </div>
+      )}
+      renderTags={(value: readonly NationalityListProps[], getTagProps) =>
+        value.map((option: NationalityListProps, index: number) => (
+          <Chip
+            label={option.name}
+            style={{
+              margin: 2,
+              border: getBoderColor(styleName),
+              color: '#000',
+            }}
+            {...getTagProps({ index })}
+          />
+        ))
+      }
+    />
+  );
+};

--- a/src/components/SelectorComponents/ShowFilterObject/ShowFilterObject.tsx
+++ b/src/components/SelectorComponents/ShowFilterObject/ShowFilterObject.tsx
@@ -38,24 +38,24 @@ const ShowFilterObject: FunctionComponent<ShowAllSelectedProps> = ({ handleViewA
                         label: item.label!,
                         searchTerm: searchTermToUse
                     });
-                } else if (item.varName === 'language_group__name') {
-                    const searchTermToUse = (item.searchTerm as string[]).join(' - ')
-                    combinedData.push({
-                        label: `Language Group`,
-                        searchTerm: searchTermToUse
-                    });
-                } else if (item.varName === 'EnslaverNameAndRole') {
+                } else if (item && Array.isArray(item.searchTerm) && item.varName === 'EnslaverNameAndRole') {
                     const roles = (item.searchTerm as RolesFilterProps[]).map((role) => role.roles.join(', ')).join(' - ');
                     const names = (item.searchTerm as RolesFilterProps[]).map((role) => role.name).join(' - ');
-                    const searchTermToUse = `${names}, Who had: ${roles} roles.`;
+                    const searchTermToUse = `${names} : ${roles}`;
                     combinedData.push({
                         label: `Enslavers`,
                         searchTerm: searchTermToUse
                     });
-                } else if (item && Array.isArray(item.searchTerm) && item.varName !== 'dataset') {
+                } else if (item && Array.isArray(item.searchTerm) && (item.varName === 'voyage_ship__imputed_nationality__name')) {
                     const names = (item.searchTerm as string[]).map((name) => name).join(', ');
                     combinedData.push({
-                        label: varName === 'voyage_ship__imputed_nationality__name' ? 'Flag of vessel (IMP)' : 'Flag of vessel',
+                        label: `Flag of vessel (IMP)`,
+                        searchTerm: names
+                    });
+                } else if (item && Array.isArray(item.searchTerm) && item.varName === 'voyage_ship__nationality_ship__name') {
+                    const names = (item.searchTerm as string[]).map((name) => name).join(', ');
+                    combinedData.push({
+                        label: `Flag of vessel`,
                         searchTerm: names
                     });
                 }

--- a/src/components/SelectorComponents/ShowFilterObject/ShowFilterObject.tsx
+++ b/src/components/SelectorComponents/ShowFilterObject/ShowFilterObject.tsx
@@ -31,6 +31,7 @@ const ShowFilterObject: FunctionComponent<ShowAllSelectedProps> = ({ handleViewA
         const combinedData: { label: string; searchTerm: number[] | string[] | CheckboxValueType[] | CheckboxValueType | RolesFilterProps[] }[] = [];
         if (Array.isArray(filter)) {
             filter.forEach((item) => {
+
                 if (item.label) {
                     const searchTermToUse = Array.isArray(item.title) ? item.title.join(', ') : (Array.isArray(item.searchTerm) ? item.searchTerm.join(' - ') : item.searchTerm);
                     combinedData.push({
@@ -44,13 +45,18 @@ const ShowFilterObject: FunctionComponent<ShowAllSelectedProps> = ({ handleViewA
                         searchTerm: searchTermToUse
                     });
                 } else if (item.varName === 'EnslaverNameAndRole') {
-
                     const roles = (item.searchTerm as RolesFilterProps[]).map((role) => role.roles.join(', ')).join(' - ');
                     const names = (item.searchTerm as RolesFilterProps[]).map((role) => role.name).join(' - ');
                     const searchTermToUse = `${names}, Who had: ${roles} roles.`;
                     combinedData.push({
                         label: `Enslavers`,
                         searchTerm: searchTermToUse
+                    });
+                } else if (item && Array.isArray(item.searchTerm) && item.varName !== 'dataset') {
+                    const names = (item.searchTerm as string[]).map((name) => name).join(', ');
+                    combinedData.push({
+                        label: varName === 'voyage_ship__imputed_nationality__name' ? 'Flag of vessel (IMP)' : 'Flag of vessel',
+                        searchTerm: names
                     });
                 }
             });

--- a/src/components/SelectorComponents/Tabs/TabsSelect.tsx
+++ b/src/components/SelectorComponents/Tabs/TabsSelect.tsx
@@ -17,14 +17,13 @@ import { usePageRouter } from '@/hooks/usePageRouter';
 
 const TabsSelect = () => {
     const dispatch: Dispatch = useDispatch();
-    const { currentBlockName, nodeTypeURL: ID } = usePageRouter();
+    const { currentBlockName, voyageURLID: ID } = usePageRouter();
     const { variable, nodeTypeClass } = useSelector((state: RootState) => state.getCardFlatObjectData);
-
     const navigate = useNavigate();
     const onChange = (key: string) => {
         dispatch(setValueVariable(key))
         dispatch(setCurrentBlockName(key))
-        navigate(`/${nodeTypeClass}/${ID}/${key}#${(key).toLowerCase()}`)
+        navigate(`/${nodeTypeClass}/${ID}#${key.toLowerCase()}`)
     };
 
     const items: TabsProps['items'] = [

--- a/src/fetch/voyagesFetch/fetchNationalityList.ts
+++ b/src/fetch/voyagesFetch/fetchNationalityList.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { AUTHTOKEN, BASEURL } from '../../share/AUTH_BASEURL';
+
+export const fetchNationalityList = async () => {
+    try {
+        const response = await axios.get(
+            `${BASEURL}/voyage/NationalityList/`,
+            {
+                headers: { 'Authorization': AUTHTOKEN },
+            }
+        );
+        return response;
+    } catch (error) {
+        throw new Error('Failed to fetchPastEnslaversOptions data');
+    }
+};

--- a/src/fetch/voyagesFetch/fetchVoyagesMap.ts
+++ b/src/fetch/voyagesFetch/fetchVoyagesMap.ts
@@ -6,7 +6,6 @@ import { MapPropsRequest } from '@/share/InterfaceTypes';
 export const fetchVoyagesMap = createAsyncThunk(
     'voyagesMap/fetchVoyagesMap',
     async (dataSend?: MapPropsRequest) => {
-
         try {
             const response = await axios.post(
                 `${BASEURL}/voyage/aggroutes/`,

--- a/src/hooks/usePageRouter.tsx
+++ b/src/hooks/usePageRouter.tsx
@@ -16,7 +16,6 @@ export function usePageRouter() {
     const blogURL = pathParts[3]
     const hash = location.hash;
     const currentBlockName = hash ? hash.slice(1) : '';
-
     return {
         styleName, typeOfPathURL,
         currentBlockName,

--- a/src/redux/getNationalityListSlice.ts
+++ b/src/redux/getNationalityListSlice.ts
@@ -1,0 +1,20 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { FilterNationalityList, NationalityListProps } from '@/share/InterfaceTypes';
+
+const initialState: FilterNationalityList = {
+    nationalityList: [],
+};
+
+const getNationalityListSlice = createSlice({
+    name: 'rangeSlider',
+    initialState,
+    reducers: {
+        setNationalityList: (state, action: PayloadAction<NationalityListProps[]>) => {
+            state.nationalityList = action.payload;
+        },
+        resetSliceNations: (state) => initialState,
+    },
+
+});
+export const { resetSliceNations, setNationalityList } = getNationalityListSlice.actions;
+export default getNationalityListSlice.reducer;

--- a/src/redux/getRangeSliderSlice.ts
+++ b/src/redux/getRangeSliderSlice.ts
@@ -10,7 +10,7 @@ const initialState: FilterObjectsState = {
     rangeSliderMinMax: {},
     enslaversNameAndRole: [],
     enslaverName: '',
-    opsRoles: 'andlist',
+    opsRoles: 'in',
     listEnslavers: []
 };
 

--- a/src/redux/getRangeSliderSlice.ts
+++ b/src/redux/getRangeSliderSlice.ts
@@ -10,7 +10,7 @@ const initialState: FilterObjectsState = {
     rangeSliderMinMax: {},
     enslaversNameAndRole: [],
     enslaverName: '',
-    opsRoles: 'in',
+    opsRoles: 'andlist',
     listEnslavers: []
 };
 

--- a/src/redux/resetAllSlice.ts
+++ b/src/redux/resetAllSlice.ts
@@ -18,6 +18,7 @@ import { resetAllStateSlice as resetAllStateSliceDataEnslaved } from './getPeopl
 import { resetAllStateSlice as resetAllStateSliceDataEnslavers } from './getPeopleEnslaversDataSetCollectionSlice'
 import { resetSliceSaveSearch } from './getSaveSearchSlice'
 import { resetSliceShowHideFilter } from './getShowFilterObjectSlice'
+import { resetSliceNations } from './getNationalityListSlice'
 
 export const resetAll = () => (dispatch: Dispatch) => {
     dispatch(resetOptionsData());
@@ -35,6 +36,7 @@ export const resetAll = () => (dispatch: Dispatch) => {
     dispatch(resetEstimateAssesment())
     dispatch(resetSliceSaveSearch())
     dispatch(resetSliceShowHideFilter())
+    dispatch(resetSliceNations())
 
 };
 
@@ -56,5 +58,6 @@ export const resetAllStateToInitailState = () => (dispatch: Dispatch) => {
     dispatch(resetEstimateAssesment())
     dispatch(resetSliceSaveSearch())
     dispatch(resetSliceShowHideFilter())
+    dispatch(resetSliceNations())
 };
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -32,6 +32,7 @@ import getEstimateAssesmentSlice from './getEstimateAssessmentSlice';
 import getSaveSearchSlice from './getSaveSearchSlice';
 import getQuerySaveSearchSlice from './getQuerySaveSearchSlice'
 import getShowFilterObjectSlice from './getShowFilterObjectSlice'
+import getNationalityListSlice from './getNationalityListSlice'
 
 
 // Define types for slices
@@ -63,6 +64,7 @@ type EstimateAssesmentSlice = ReturnType<typeof getEstimateAssesmentSlice>;
 type SaveSearchSlice = ReturnType<typeof getSaveSearchSlice>;
 type QuerySaveSearchSlice = ReturnType<typeof getQuerySaveSearchSlice>;
 type ShowFilterObjectSlice = ReturnType<typeof getShowFilterObjectSlice>;
+type NationalityListSlice = ReturnType<typeof getNationalityListSlice>;
 
 // Define RootState
 export type RootState = {
@@ -94,6 +96,7 @@ export type RootState = {
         getSaveSearch: SaveSearchSlice
         getQuerySaveSearch: QuerySaveSearchSlice
         getShowFilterObject: ShowFilterObjectSlice
+        getNationalityList: NationalityListSlice
         [voyagesApi.reducerPath]: ReturnType<typeof voyagesApi.reducer>;
 };
 
@@ -127,6 +130,7 @@ const store = configureStore({
                 getSaveSearch: getSaveSearchSlice,
                 getQuerySaveSearch: getQuerySaveSearchSlice,
                 getShowFilterObject: getShowFilterObjectSlice,
+                getNationalityList: getNationalityListSlice,
                 [voyagesApi.reducerPath]: voyagesApi.reducer,
                 [pastEnslavedService.reducerPath]: pastEnslavedService.reducer,
                 [pastEnslaversService.reducerPath]: pastEnslaversService.reducer,

--- a/src/share/InterfaceTypes.ts
+++ b/src/share/InterfaceTypes.ts
@@ -30,6 +30,14 @@ export interface FilterObjectsState {
     opsRoles?: string
     listEnslavers: RolesProps[]
 }
+export interface FilterNationalityList {
+    nationalityList: NationalityListProps[]
+}
+export interface NationalityListProps {
+    id: number;
+    name: string;
+    value: number;
+}
 export interface RangeSliderMinMaxInitialState {
     [key: string]: number[]
 }
@@ -99,6 +107,7 @@ export const TYPES: {
     LanguageTreeSelect: string
     EnslaverNameAndRole: string
     VoyageID: string
+    MultiselectList: string
 } = {
     IntegerField: 'IntegerField',
     DecimalField: 'DecimalField',
@@ -107,7 +116,8 @@ export const TYPES: {
     GeoTreeSelect: 'GeoTreeSelect',
     LanguageTreeSelect: 'LanguageTreeSelect',
     EnslaverNameAndRole: 'EnslaverNameAndRole',
-    VoyageID: 'id_match'
+    VoyageID: 'id_match',
+    MultiselectList: 'MultiselectList'
 };
 
 export const TYPESOFDATASETPEOPLE: {

--- a/src/share/InterfaceTypes.ts
+++ b/src/share/InterfaceTypes.ts
@@ -34,9 +34,9 @@ export interface FilterNationalityList {
     nationalityList: NationalityListProps[]
 }
 export interface NationalityListProps {
-    id: number;
+    id?: number;
     name: string;
-    value: number;
+    value?: number;
 }
 export interface RangeSliderMinMaxInitialState {
     [key: string]: number[]

--- a/src/styleMUI/index.ts
+++ b/src/styleMUI/index.ts
@@ -6,6 +6,7 @@ import { SxProps, } from '@mui/material';
 import NestedMenuItems from '@/components/SelectorComponents/Cascading/NestedMeneItems';
 import { styled, } from '@mui/material/styles';
 import { color } from 'framer-motion';
+import { minWidth } from '@mui/system';
 
 const blue500 = '#42a5f5';
 export const MAINBGGREEN = 'rgba(0, 128, 128, 0.5)'
@@ -172,6 +173,7 @@ export const DialogModalStyle = {
 };
 export const PaperDraggableStyle = {
   maxWidth: 500,
+  minWidth: 500
 }
 export const TextFieldSearch = styled(TextField)`
   & label.Mui-focused {

--- a/src/utils/flatfiles/transatlantic_voyages_filter_menu.json
+++ b/src/utils/flatfiles/transatlantic_voyages_filter_menu.json
@@ -133,7 +133,7 @@
 				"children": [
 					{
 						"var_name": "voyage_ship__nationality_ship__name",
-						"type": "CharField",
+						"type": "MultiselectList",
 						"ops": [
 							"icontains"
 						],
@@ -145,7 +145,7 @@
 					},
 					{
 						"var_name": "voyage_ship__imputed_nationality__name",
-						"type": "CharField",
+						"type": "MultiselectList",
 						"ops": [
 							"icontains"
 						],

--- a/src/utils/functions/checkPagesRoute.ts
+++ b/src/utils/functions/checkPagesRoute.ts
@@ -13,17 +13,11 @@ import { TYPESOFDATASET } from '@/share/InterfaceTypes';
 export const checkPagesRouteForVoyages = (pathStyleRoute: string) => {
     switch (pathStyleRoute) {
         case TYPESOFDATASET.allVoyages:
+        case TYPESOFDATASET.voyages:
+        case TYPESOFDATASET.voyage:
         case TYPESOFDATASET.intraAmerican:
         case TYPESOFDATASET.transatlantic:
         case TYPESOFDATASET.texas:
-            return true;
-        default:
-            return false;
-    }
-};
-export const checkPagesRouteMapURLForVoyages = (pathStyleRoute: string) => {
-    switch (pathStyleRoute) {
-        case TYPESOFDATASET.voyages:
             return true;
         default:
             return false;
@@ -35,19 +29,13 @@ export const checkPagesRouteForEnslaved = (pathStyleRoute: string) => {
         case ALLENSLAVED:
         case AFRICANORIGINS:
         case ENSLAVEDTEXAS:
-            return true;
-        default:
-            return false;
-    }
-};
-export const checkPagesRouteMapURLForEnslaved = (pathStyleRoute: string) => {
-    switch (pathStyleRoute) {
         case ENSALVEDTYPE:
             return true;
         default:
             return false;
     }
 };
+
 export const checkPagesRouteForEnslavers = (pathStyleRoute: string) => {
 
     switch (pathStyleRoute) {

--- a/src/utils/functions/customValueFormatter.ts
+++ b/src/utils/functions/customValueFormatter.ts
@@ -1,12 +1,13 @@
 // Define a custom value formatter function
 export const customValueFormatter = (params: any) => {
     const { value } = params; // Extract the value from the params object
+
     // Perform custom formatting based on your requirements
     let formattedValue = ''; // Initialize the formatted value variable
 
     if (typeof value === 'number') {
         formattedValue = value.toLocaleString('en-US'); // Format numbers with commas
-    } else {
+    } else if (value) {
         formattedValue = value.toString(); // Convert non-numeric values to strings
     }
 

--- a/src/utils/functions/updateFilterTextDialog.ts
+++ b/src/utils/functions/updateFilterTextDialog.ts
@@ -4,7 +4,7 @@ import { AppDispatch } from "@/redux/store";
 import { allEnslavers } from "@/share/CONST_DATA";
 import { Filter, TYPESOFDATASET, TYPESOFDATASETPEOPLE } from "@/share/InterfaceTypes";
 
-export function updatedEnslaversRoleAndNameToLocalStorage(dispatch: AppDispatch, styleNameRoute: string, listEnslavers: string[], enslaverName: string, varName: string, opsRoles: string) {
+export const updateFilterTextDialog = (dispatch: AppDispatch, newValue: string, styleNameRoute: string, varName: string, ops: string, opsRoles: string, labelVarName: string) => {
     const existingFilterObjectString = localStorage.getItem('filterObject');
     let existingFilters: Filter[] = [];
 
@@ -16,15 +16,20 @@ export function updatedEnslaversRoleAndNameToLocalStorage(dispatch: AppDispatch,
         (filter) => filter.varName === varName
     );
 
-    if (listEnslavers.length > 0) {
+    if (newValue.length > 0) {
         if (existingFilterIndex !== -1) {
-            existingFilters[existingFilterIndex].searchTerm = [{ roles: listEnslavers, name: enslaverName }]
-            existingFilters[existingFilterIndex].op = opsRoles!
+            existingFilters[existingFilterIndex].searchTerm = ops === 'icontains' || (ops === 'exact') ? newValue as string : [newValue]
+            if (existingFilters[existingFilterIndex].op === 'icontains') {
+                existingFilters[existingFilterIndex].op = ops!
+            } else {
+                existingFilters[existingFilterIndex].op = opsRoles!
+            }
         } else {
             existingFilters.push({
                 varName: varName,
-                searchTerm: [{ roles: listEnslavers, name: enslaverName }],
-                op: opsRoles!,
+                searchTerm: (ops === 'icontains') || (ops === 'exact') ? newValue as string : [newValue],
+                op: ops,
+                label: labelVarName
             });
         }
     } else if (existingFilterIndex !== -1) {
@@ -34,12 +39,15 @@ export function updatedEnslaversRoleAndNameToLocalStorage(dispatch: AppDispatch,
     const filteredFilters = existingFilters.filter((filter) =>
         !Array.isArray(filter.searchTerm) || filter.searchTerm.length > 0
     );
+
     const filterObjectUpdate = {
         filter: filteredFilters,
     };
 
+
     const filterObjectString = JSON.stringify(filterObjectUpdate);
     localStorage.setItem('filterObject', filterObjectString)
+
     dispatch(setFilterObject(filteredFilters));
     if ((styleNameRoute === TYPESOFDATASET.allVoyages || styleNameRoute === TYPESOFDATASETPEOPLE.allEnslaved || styleNameRoute === allEnslavers) && filteredFilters.length > 0) {
         dispatch(setIsViewButtonViewAllResetAll(true))

--- a/src/utils/functions/updateNationalityObject.ts
+++ b/src/utils/functions/updateNationalityObject.ts
@@ -4,43 +4,50 @@ import { AppDispatch } from "@/redux/store";
 import { allEnslavers } from "@/share/CONST_DATA";
 import { Filter, TYPESOFDATASET, TYPESOFDATASETPEOPLE } from "@/share/InterfaceTypes";
 
-export function updatedEnslaversRoleAndNameToLocalStorage(dispatch: AppDispatch, styleNameRoute: string, listEnslavers: string[], enslaverName: string, varName: string, opsRoles: string) {
+export const updateNationalityObject = (dispatch: AppDispatch, valueSelect: string[], varName: string, styleNameRoute: string) => {
     const existingFilterObjectString = localStorage.getItem('filterObject');
     let existingFilters: Filter[] = [];
 
     if (existingFilterObjectString) {
         existingFilters = JSON.parse(existingFilterObjectString).filter || [];
     }
-
     const existingFilterIndex = existingFilters.findIndex(
         (filter) => filter.varName === varName
     );
-
-    if (listEnslavers.length > 0) {
+    // Type guard to check if autuLabels is an array before accessing its length property
+    if (Array.isArray(valueSelect) && valueSelect.length > 0) {
         if (existingFilterIndex !== -1) {
-            existingFilters[existingFilterIndex].searchTerm = [{ roles: listEnslavers, name: enslaverName }]
-            existingFilters[existingFilterIndex].op = opsRoles!
+            existingFilters[existingFilterIndex].searchTerm = [...valueSelect];
         } else {
             existingFilters.push({
                 varName: varName,
-                searchTerm: [{ roles: listEnslavers, name: enslaverName }],
-                op: opsRoles!,
+                searchTerm: valueSelect,
+                op: 'in',
+                // label: labelVarName,
+                // title: selectedTitles
             });
         }
-    } else if (existingFilterIndex !== -1) {
+    } else if (
+        existingFilterIndex !== -1 &&
+        Array.isArray(existingFilters[existingFilterIndex].searchTerm) &&
+        existingFilters[existingFilterIndex].searchTerm
+    ) {
         existingFilters[existingFilterIndex].searchTerm = [];
     }
 
-    const filteredFilters = existingFilters.filter((filter) =>
-        !Array.isArray(filter.searchTerm) || filter.searchTerm.length > 0
+    const filteredFilters = existingFilters.filter(
+        (filter) =>
+            Array.isArray(filter.searchTerm) && filter.searchTerm.length > 0
     );
+
+    dispatch(setFilterObject(filteredFilters));
+
     const filterObjectUpdate = {
         filter: filteredFilters,
     };
 
     const filterObjectString = JSON.stringify(filterObjectUpdate);
-    localStorage.setItem('filterObject', filterObjectString)
-    dispatch(setFilterObject(filteredFilters));
+    localStorage.setItem('filterObject', filterObjectString);
     if ((styleNameRoute === TYPESOFDATASET.allVoyages || styleNameRoute === TYPESOFDATASETPEOPLE.allEnslaved || styleNameRoute === allEnslavers) && filteredFilters.length > 0) {
         dispatch(setIsViewButtonViewAllResetAll(true))
     } else if (filteredFilters.length > 1) {

--- a/src/utils/languages/home_page_text.ts
+++ b/src/utils/languages/home_page_text.ts
@@ -163,8 +163,8 @@ export const homePageTranslated: TranslateType = {
     homeEnslavers: {
         label: {
             "en": "Enslavers",
-            "es": "Almácenistas",
-            "pt": "Comerciantes de Escravos",
+            "es": "Esclavizadores",
+            "pt": "Escravizadores",
         }
     },
     homeEnslaversDes: {


### PR DESCRIPTION
- Translate enslavers home page
- Show selection options for "Flag of vessel" and "Flag of vessel (IMP)" filters in all database pages
![Screenshot 2024-05-29 at 8 21 00 AM](https://github.com/rice-crc/voyages-frontend/assets/132945616/8a67f3dc-8e32-439d-aa87-755630f7d4f1)
![Screenshot 2024-05-29 at 8 21 08 AM](https://github.com/rice-crc/voyages-frontend/assets/132945616/fdffff6d-52d1-43d3-8627-1f7bdea39c16)

* DD-0202: Show selection options for "Flag of the vessel" and "Flag of the vessel (IMP)" filters in all database pages
* DD-0207: Voyage and people cards not loading from the document viewer
* DE-0203: Search for vessel name produces no results
* TP-0204: Search Enslavers Name is no result on the second time
* TP-0208: Geo Tree is not updated on the filter object 
* JM-0206:  Pivot table searches, The pivot table is acting strangely.
* DD-0136: [Revisit Later-Styling] Adjust the width and white space between columns of African Origins
* JH-0169: "Outcomes" and "Resistance," no options are given for searching (I tried uprising, for instance, and nothing appeared). 
* TP-0209: VisibleColumnCells is reset back to default when sorting columns 
