### PR TITLE
fix: show text popup for single (non-clustered) post-disembarkation markers instead of empty popup

### DIFF
--- a/src/components/PresentationComponents/Map/NodeEdgesCurvedLinesMap.tsx
+++ b/src/components/PresentationComponents/Map/NodeEdgesCurvedLinesMap.tsx
@@ -118,7 +118,7 @@ const NodeEdgesCurvedLinesMap = () => {
       spiderfyOnMaxZoom: false,
       iconCreateFunction: function (cluster) {
         const childCount = cluster.getChildCount();
-        let c = ' marker-cluster-';
+        let c = 'marker-cluster-';
         if (childCount < 10) {
           c += 'large';
         } else if (childCount < 100) {
@@ -222,29 +222,43 @@ const NodeEdgesCurvedLinesMap = () => {
           nodeID,
         );
 
-        const popupContent = createTooltipEmbarkDiseEmbarkEdges(node);
-
-        circleMarker.bindPopup(popupContent).bringToFront();
-
         const originMarker = L.marker(latlon);
-        circleMarker.on('mouseover', (event) => {
-          circleMarker.openPopup();
-          handleHoverCircleMarker(
-            event,
-            hiddenEdgesLayer,
-            edgesData,
-            nodesData,
-            node,
-            originNodeMarkersMap,
-            originMarkerCluster,
-            handleSetClusterKeyValue, // WAIT To Change if want to show table,
-            map,
-          );
-        });
 
         if (disembarkation !== 0 || embarkation !== 0) {
+          const popupContent = createTooltipEmbarkDiseEmbarkEdges(node);
+          circleMarker.bindPopup(popupContent).bringToFront();
+          circleMarker.on('mouseover', (event) => {
+            circleMarker.openPopup();
+            handleHoverCircleMarker(
+              event,
+              hiddenEdgesLayer,
+              edgesData,
+              nodesData,
+              node,
+              originNodeMarkersMap,
+              originMarkerCluster,
+              handleSetClusterKeyValue,
+              map,
+            );
+          });
           circleMarker.addTo(map).bringToFront();
         } else if (origin && origin > 0) {
+          const popupContent = createTooltipEmbarkDiseEmbarkEdges(node);
+          circleMarker.bindPopup(popupContent).bringToFront();
+          circleMarker.on('mouseover', (event) => {
+            circleMarker.openPopup();
+            handleHoverCircleMarker(
+              event,
+              hiddenEdgesLayer,
+              edgesData,
+              nodesData,
+              node,
+              originNodeMarkersMap,
+              originMarkerCluster,
+              handleSetClusterKeyValue,
+              map,
+            );
+          });
           originNodeMarkersMap.set(nodeID, originMarker);
           originMarkerCluster.addLayer(circleMarker).bringToFront();
           originMarkerCluster.addLayer(originMarker).bringToFront();
@@ -254,6 +268,13 @@ const NodeEdgesCurvedLinesMap = () => {
           disembarkation === 0 &&
           embarkation === 0
         ) {
+          const count = Number(post_disembarkation);
+          const peopleText = count === 1 ? 'person' : 'people';
+          const popupText = `<p>${node.data.name} is the final known location for ${count} enslaved ${peopleText}.</p>`;
+          circleMarker.bindPopup(popupText);
+          circleMarker.on('mouseover', () => {
+            circleMarker.openPopup();
+          });
           postDisembarkationsMarkerCluster
             .addLayer(circleMarker)
             .bringToFront();

--- a/src/components/PresentationComponents/Map/NodeEdgesCurvedLinesMap.tsx
+++ b/src/components/PresentationComponents/Map/NodeEdgesCurvedLinesMap.tsx
@@ -186,7 +186,19 @@ const NodeEdgesCurvedLinesMap = () => {
           iconSize: new L.Point(40, 40, true),
         });
       },
-    }).on('clustermouseover', (event) => {
+    })
+    .on('clustermouseover', (event) => {
+      handleHoverMarkerCluster(
+        event,
+        hiddenEdgesLayer,
+        hiddenEdges,
+        nodesData,
+        nodeTypePostDisembarkation,
+        handleSetClusterKeyValue,
+        map,
+      );
+    })
+    .on('mouseover', (event) => {
       handleHoverMarkerCluster(
         event,
         hiddenEdgesLayer,
@@ -268,13 +280,6 @@ const NodeEdgesCurvedLinesMap = () => {
           disembarkation === 0 &&
           embarkation === 0
         ) {
-          const count = Number(post_disembarkation);
-          const peopleText = count === 1 ? 'person' : 'people';
-          const popupText = `<p>${node.data.name} is the final known location for ${count} enslaved ${peopleText}.</p>`;
-          circleMarker.bindPopup(popupText);
-          circleMarker.on('mouseover', () => {
-            circleMarker.openPopup();
-          });
           postDisembarkationsMarkerCluster
             .addLayer(circleMarker)
             .bringToFront();

--- a/src/components/PresentationComponents/Map/handleHoverCircleMarker.tsx
+++ b/src/components/PresentationComponents/Map/handleHoverCircleMarker.tsx
@@ -9,8 +9,6 @@ import renderEdgesAnimatedLinesOnMap from './renderEdgesAnimatedLinesOnMap';
 import renderEdgesLinesOnMap from './renderEdgesLinesOnMap';
 import { createSourceAndTargetDictionariesNodeEdges } from '../../../utils/functions/createSourceAndTargetDictionariesNodeEdges';
 import { createLogNodeValueScale } from '@/utils/functions/createLogNodeValueScale';
-import { createRoot } from 'react-dom/client';
-import { TooltipHoverTableOnNode } from './TooltipHoverTableOnNode';
 import { createTooltipClusterEdges } from '@/utils/functions/createTooltipClusterEdges';
 
 export function handleHoverCircleMarker(
@@ -68,22 +66,7 @@ export function handleHoverCircleMarker(
       }
     }
   });
-  /**
-   ====  WAIT To discuss Keep the labes for now ===== 
-   const popupContainer = document.createElement('center');
-   popupContainer.className = 'tablePopup'
-  popupContainer.style.width = '300px'
-  const popupRoot = createRoot(popupContainer);
-  popupRoot.render(
-    <TooltipHoverTableOnNode
-      nodesDatas={nodesData}
-      nodeType={''}
-      handleSetClusterKeyValue={handleSetClusterKeyValue}
-    />
-  );
-  event.target.bindPopup(popupContainer).openPopup();
-   **/
-
+  
   for (const [, edgeData] of aggregatedEdges) {
     const { sourceLatlng, targetLatlng, controls, type, weight } = edgeData;
 

--- a/src/components/PresentationComponents/Map/handleHoverMarkerCluster.tsx
+++ b/src/components/PresentationComponents/Map/handleHoverMarkerCluster.tsx
@@ -19,8 +19,10 @@ export function handleHoverMarkerCluster(
 ) {
   hiddenEdgesLayer.clearLayers();
   const nodeLogValueScale = createLogNodeValueScale(nodesData);
-  const clusterLatLon = event.layer.getLatLng();
-  const clusterChildMarkers = event.layer.getAllChildMarkers();
+  const layer = (event.propagatedFrom ?? (event as any).layer) as any;
+  const isCluster = typeof layer.getAllChildMarkers === 'function';
+  const clusterLatLon = layer.getLatLng();
+  const clusterChildMarkers = isCluster ? layer.getAllChildMarkers() : [layer];
   const targetNodeMap = new Map<string, [NodeAggroutes, EdgesAggroutes]>();
 
   const nodeIdsClusters = clusterChildMarkers.map(
@@ -93,13 +95,20 @@ export function handleHoverMarkerCluster(
     );
   }
 
-  popupRoot.render(
-    <TooltipHoverTableOnNode
-      nodesDatas={childNodesData}
-      nodeType={nodeType}
-      handleSetClusterKeyValue={handleSetClusterKeyValue}
-    />
-  );
-
-  event.layer.bindPopup(popupContainer).openPopup();
+  if (!isCluster && childNodesData.length === 1) {
+    const singleNode = childNodesData[0];
+    const count = Number(singleNode.weights.post_disembarkation);
+    const peopleText = count === 1 ? 'person' : 'people';
+    const popupText = `<p>${singleNode.data.name} is the final known location for ${count} enslaved ${peopleText}.</p>`;
+    layer.bindPopup(popupText).openPopup();
+  } else {
+    popupRoot.render(
+      <TooltipHoverTableOnNode
+        nodesDatas={childNodesData}
+        nodeType={nodeType}
+        handleSetClusterKeyValue={handleSetClusterKeyValue}
+      />
+    );
+    layer.bindPopup(popupContainer).openPopup();
+  }
 }

--- a/src/pages/VoyagesPage.tsx
+++ b/src/pages/VoyagesPage.tsx
@@ -86,9 +86,9 @@ const VoyagesPage = () => {
           'Explore all slave trade voyages database with comprehensive records, statistics, and visualizations.';
         break;
       case INDIANOCEANANDASIANSLAVETRADEDATABASE:
-        baseTitle = 'Indian Ocean & Asia Slave Trades';
+        baseTitle = 'Indian Ocean';
         baseDescription =
-          'Explore the Indian Ocean & Asia slave trade voyages database with detailed records, statistics, and visualizations.';
+          'Explore the Indian Ocean database\'s detailed records, statistics, and visualizations.';
         break;
       default:
         baseTitle = 'Slave Voyages';

--- a/src/share/CONST_DATA.ts
+++ b/src/share/CONST_DATA.ts
@@ -151,7 +151,7 @@ export const TransAtlanticTitle = 'Trans-Atlantic';
 export const IntraAmericanTitle = 'Intra-American';
 export const AllVoyagesTitle = 'All Voyages';
 export const IndianOceanAndAsiaSlaveTradesTitle =
-  'Indian Ocean & Asia Slave Trades';
+  'Indian Ocean';
 export const AllEnslavedPeople = 'All Enslaved People';
 export const AfricanOriginsTransAtlantic = 'African Origins/Trans-Atlantic';
 export const TEXBOUND = 'Texas Bound';

--- a/src/utils/flatfiles/voyages/voyages_collections.json
+++ b/src/utils/flatfiles/voyages/voyages_collections.json
@@ -166,7 +166,7 @@
         "es": "Océano Índico",
         "pt": "Oceano Índico"
       },
-      "text_introduce": "The Indian Ocean and Asia Slave Trades is a comprehensive database of slave trade voyages in the Indian Ocean and Asia. It includes voyages from Africa to the Americas, as well as voyages from the Americas to Africa."
+      "text_introduce": "The Indian Ocean Database is a comprehensive database of slave trade voyages in the Indian Ocean and Asia. It includes voyages from Africa to the Americas, as well as voyages from the Americas to Africa."
     },
     "base_filter": [
     {


### PR DESCRIPTION


## Summary

Fix empty popup on single (non-clustered) post-disembarkation (yellow) nodes on the enslaved Sankey map. When a yellow node appears as a standalone marker rather than part of a cluster, hovering now shows a descriptive text popup: "{Location} is the final known location for {N} enslaved people/person." Previously these markers showed an empty popup because the generic popup generator only handled embarkation/disembarkation weights.

## Deployment Instructions

None

## Testing Performed

- Hovered over isolated yellow (post-disembarkation) markers — popup now displays the correct text format
- Hovered over yellow marker clusters — table popup still appears as expected (no regression)
- Hovered over green (origin) and red (embarkation/disembarkation) markers — behavior unchanged

## Ready to Merge?

When you are ready for the Pull Request to be merged, leave a comment on the PR with this exact text:

```
@derekjkeller This PR is ready to merge.
```

PRs without this comment will not be considered for merging.
